### PR TITLE
Encapsulating evaluation logic

### DIFF
--- a/frontend/ast.cpp
+++ b/frontend/ast.cpp
@@ -1,266 +1,300 @@
 #include <iostream>
+#include <system_error>
 #include <vector>
 #include <iomanip>
 #include "ast.h"
+#include "../runtime/interpreter_part.h"
 
 using namespace std;
 
 namespace ast_types{
     
 
-    string toString(NodeType a){
-        switch (a)
-        {
-        case NodeType::Program:
-            return "Program";
-        case NodeType::Break_Interrupt:
-            return "Break Statement";
-        default:
-            return "Invalid";
-        }
+  string toString(NodeType a){
+    switch (a){
+      case NodeType::Program:
+        return "Program";
+      case NodeType::Break_Interrupt:
+        return "Break Statement";
+      default:
+        return "Invalid";
+    }
+  }
+
+  void Statement::setNodeType(NodeType NodeKind){type  = NodeKind;}
+  NodeType Statement::getNodeType(){return type;}
+
+
+  Program::Program(){
+    type = NodeType::Program;
+  }
+
+  void Program::printNode(int i = 0) {
+    cout << "Program : " << endl;
+    for(int i = 0;i < body.size();i++){
+      body[i]->printNode(i+1);
+    }   
+  }  
+
+  values::RuntimeValue* Program::evaluate_node(environment::Environment* env){
+    return interpreter_functions::evaluate_program(this,env);
+  }
+
+  BinaryExpression::BinaryExpression(
+    Expression* left_exp,
+    Expression* right_exp,
+    string bin_op
+  ){
+    left = left_exp;
+    right = right_exp;
+    binary_operator = bin_op;
+    setNodeType(NodeType::Binary_Expression);
+  }
+
+  void BinaryExpression::printNode(int i){
+    cout << "Binary Expression : " <<endl;
+    Statement::indent(i);
+    cout << "Left  : " ;left->printNode(i+1);
+    Statement::indent(i);
+    cout << "Right : " ;right->printNode(i+1);
+    Statement::indent(i);
+    cout << "operator : " << binary_operator << endl; 
     }
 
-    void Statement::setNodeType(NodeType NodeKind){type  = NodeKind;}
-    NodeType Statement::getNodeType(){return type;}
-
-
-    Program::Program(){
-        type = NodeType::Program;
-    }
-
-    void Program::printNode(int i = 0) {
-        cout << "Program : " << endl;
-        for(int i = 0;i < body.size();i++){
-            body[i]->printNode(i+1);
-        }   
-    }  
-
-    values::RuntimeValue* Program::evaluate_node(environment::Environment* env){}
-
-    BinaryExpression::BinaryExpression(
-        Expression* left_exp,
-        Expression* right_exp,
-        string bin_op
-    ){
-        left = left_exp;
-        right = right_exp;
-        binary_operator = bin_op;
-        setNodeType(NodeType::Binary_Expression);
-    }
-
-    void BinaryExpression::printNode(int i){
-        cout << "Binary Expression : " <<endl;
-        Statement::indent(i);
-        cout << "Left  : " ;left->printNode(i+1);
-        Statement::indent(i);
-        cout << "Right : " ;right->printNode(i+1);
-        Statement::indent(i);
-        cout << "operator : " << binary_operator << endl; 
-    }
-
-    values::RuntimeValue* BinaryExpression::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* BinaryExpression::evaluate_node(environment::Environment* env){
+    return interpreter_functions::eval_binary_expr(this, env);
+  }
         
-    ConditionalExpression::ConditionalExpression(
-        Expression* left_exp,
-        Expression* right_exp,
-        string conditional_op
-    ){
-        left = left_exp;
-        right = right_exp;
-        conditional_operator = conditional_op;
-        setNodeType(NodeType::Conditional_Expression);
+  ConditionalExpression::ConditionalExpression(
+    Expression* left_exp,
+    Expression* right_exp,
+    string conditional_op
+  ){
+    left = left_exp;
+    right = right_exp;
+    conditional_operator = conditional_op;
+    setNodeType(NodeType::Conditional_Expression);
     }
 
-    void ConditionalExpression::printNode(int i){
-        cout << "Conditional Expression : " <<endl;
-        Statement::indent(i);
-        cout << "Left  : " ;left->printNode(i+1);
-        Statement::indent(i);
-        cout << "Right : " ;right->printNode(i+1);
-        Statement::indent(i);
-        cout << "operator : " << conditional_operator << endl; 
-    }
+  void ConditionalExpression::printNode(int i){
+    cout << "Conditional Expression : " <<endl;
+    Statement::indent(i);
+    cout << "Left  : " ;left->printNode(i+1);
+    Statement::indent(i);
+    cout << "Right : " ;right->printNode(i+1);
+    Statement::indent(i);
+    cout << "operator : " << conditional_operator << endl; 
+  }
 
-    values::RuntimeValue* ConditionalExpression::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* ConditionalExpression::evaluate_node(environment::Environment* env){
+    return interpreter_functions::eval_conditional_expr(this,env);
+  }
 
-    NumericLiteral::NumericLiteral(string num){
-        value = stoi(num);
-        setNodeType(NodeType::NumericLiteral);
-    }
+  NumericLiteral::NumericLiteral(string num){
+    value = stoi(num);
+    setNodeType(NodeType::NumericLiteral);
+  }
 
-    void NumericLiteral::printNode(int i) {
-        cout << "NumericLiteral : " << endl;
-        Statement::indent(i);
-        cout << "value : " << fixed << setprecision(3) << value << endl;
-    }
+  void NumericLiteral::printNode(int i) {
+    cout << "NumericLiteral : " << endl;
+    Statement::indent(i);
+    cout << "value : " << fixed << setprecision(3) << value << endl;
+  }
 
-    values::RuntimeValue* NumericLiteral::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* NumericLiteral::evaluate_node(environment::Environment* env){
+    ast_types::NumericLiteral* numeric_literal_ptr= dynamic_cast<NumericLiteral*>(this);
+    int int_value = numeric_literal_ptr->value;
+    return new values::NumberValue(int_value);
+  }
 
-    BooleanLiteral::BooleanLiteral(string data){
-        if(data == "true") value = true;
-        else value = false;
-        setNodeType(NodeType::BooleanLiteral);
-    }
+  BooleanLiteral::BooleanLiteral(string data){
+    if(data == "true") value = true;
+    else value = false;
+    setNodeType(NodeType::BooleanLiteral);
+  }
 
-    void BooleanLiteral::printNode(int i) {
-        cout << "BooleanLiteral : " << endl;
-        Statement::indent(i);
-        cout << "flag : " << value << endl;
-    }
-    values::RuntimeValue* BooleanLiteral::evaluate_node(environment::Environment* env){}
+  void BooleanLiteral::printNode(int i) {
+    cout << "BooleanLiteral : " << endl;
+    Statement::indent(i);
+    cout << "flag : " << value << endl;
+  }
+
+  values::RuntimeValue* BooleanLiteral::evaluate_node(environment::Environment* env){
+    BooleanLiteral* boolean_literal_ptr= dynamic_cast<BooleanLiteral*>(this);
+    bool bool_value = boolean_literal_ptr->value;
+    return new values::BooleanValue(bool_value);
+  }
     
-    StringLiteral::StringLiteral(string word){
-        value = word;
-        setNodeType(NodeType::StringLiteral);
-    }
+  StringLiteral::StringLiteral(string word){
+    value = word;
+    setNodeType(NodeType::StringLiteral);
+  }
 
-    void StringLiteral::printNode(int i) {
-        cout << "StringLiteral : " << endl;
-        Statement::indent(i);
-        cout << "value : " << fixed << setprecision(3) << value << endl;
-    }
+  void StringLiteral::printNode(int i) {
+    cout << "StringLiteral : " << endl;
+    Statement::indent(i);
+    cout << "value : " << fixed << setprecision(3) << value << endl;
+  }
 
-
-    values::RuntimeValue* StringLiteral::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* StringLiteral::evaluate_node(environment::Environment* env){
+    StringLiteral* string_literal_ptr= dynamic_cast<StringLiteral*>(this);
+    string string_value = string_literal_ptr->value;
+    return new values::StringValue(string_value);
+  }
     
-    Identifier::Identifier(string value){
-        symbol = value;
-        setNodeType(NodeType::Identifier);
-    }
+  Identifier::Identifier(string value){
+    symbol = value;
+    setNodeType(NodeType::Identifier);
+  }
 
-    void Identifier::printNode(int i) {
-        cout << "Identifier : " << endl;
-        Statement::indent(i);
-        cout << "value : " << symbol << endl;
-    }
+  void Identifier::printNode(int i) {
+    cout << "Identifier : " << endl;
+    Statement::indent(i);
+    cout << "value : " << symbol << endl;
+  }
   
-    values::RuntimeValue* Identifier::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* Identifier::evaluate_node(environment::Environment* env){
+    Identifier* Identifier_ptr = dynamic_cast<Identifier*>(this);
+    if(Identifier_ptr->symbol == "null"){return new values::NullValue();}
+    return interpreter_functions::evaluate_identifier(this,env);
+  }
   
-    void yoyo(){
-        cout << "heloo dude"<< endl;
+  void yoyo(){
+    cout << "heloo dude"<< endl;
+  }
+
+  Variable_Declaration::Variable_Declaration(Identifier* name,Expression* expr,DataTypes type,bool isNullable){
+    varName = name;
+    expression = expr;
+    datatype = type;
+    nullable = isNullable;
+    if(datatype == DataTypes::Number){
+    // runtime_values hepls to find what valuetype it will evaluate to 
+      runtime_value = values::ValueType::Number;
+      }else if(datatype == DataTypes::Bool){
+        runtime_value = values::ValueType::Boolean;
+      }else if(datatype == DataTypes::String){
+        runtime_value = values::ValueType::String;
+      }else{
+        throw runtime_error("from ast.cpp variabledec :: unknown datatype");
+      }
+      setNodeType(NodeType::Variable_Declaration);
     }
 
-    Variable_Declaration::Variable_Declaration(Identifier* name,Expression* expr,DataTypes type,bool isNullable){
-        varName = name;
-        expression = expr;
-        datatype = type;
-        nullable = isNullable;
-        if(datatype == DataTypes::Number){
-        // runtime_values hepls to find what valuetype it will evaluate to 
-            runtime_value = values::ValueType::Number;
-        }else if(datatype == DataTypes::Bool){
-            runtime_value = values::ValueType::Boolean;
-        }else if(datatype == DataTypes::String){
-            runtime_value = values::ValueType::String;
-        }else{
-           throw runtime_error("from ast.cpp variabledec :: unknown datatype");
-        }
-        setNodeType(NodeType::Variable_Declaration);
-    }
+  void Variable_Declaration::printNode(int i) {
+    cout << "Variable_Declaration : " << endl;
+    Statement::indent(i);
+    cout << "variable Name : ";
+    varName->printNode(i+1);
+    Statement::indent(i);
+    cout << "Expr : ";
+    expression->printNode(i+1);
+    Statement::indent(i);
+    cout << "type : " + values::tostring(runtime_value)<<endl;    
+  }
 
-    void Variable_Declaration::printNode(int i) {
-        cout << "Variable_Declaration : " << endl;
-        Statement::indent(i);
-        cout << "variable Name : ";
-        varName->printNode(i+1);
-        Statement::indent(i);
-        cout << "Expr : ";
-        expression->printNode(i+1);
-        Statement::indent(i);
-        cout << "type : " + values::tostring(runtime_value)<<endl;
-        
-    }
+  values::RuntimeValue* Variable_Declaration::evaluate_node(environment::Environment* env){
+    return interpreter_functions::eval_variable_declaration(this, env);
+  }
 
-    values::RuntimeValue* Variable_Declaration::evaluate_node(environment::Environment* env){}
+  Variable_Assignment::Variable_Assignment(Identifier* name,Expression* expr,DataTypes type){
+    varName = name;
+    expression = expr;
+    setNodeType(NodeType::Variable_Assignment);
+  }
 
-    Variable_Assignment::Variable_Assignment(Identifier* name,Expression* expr,DataTypes type){
-        varName = name;
-        expression = expr;
-        setNodeType(NodeType::Variable_Assignment);
-    }
+  void Variable_Assignment::printNode(int i) {
+    cout << "Variable_Assignment : " << endl;
+    Statement::indent(i);
+    cout << "Identifier : ";
+    varName->printNode(i+1);
+    Statement::indent(i);
+    cout << "Expr : ";
+    expression->printNode(i+1);
+  }
 
-    void Variable_Assignment::printNode(int i) {
-        cout << "Variable_Assignment : " << endl;
-        Statement::indent(i);
-        cout << "Identifier : ";
-        varName->printNode(i+1);
-        Statement::indent(i);
-        cout << "Expr : ";
-        expression->printNode(i+1);
-    }
-
-    values::RuntimeValue* Variable_Assignment::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* Variable_Assignment::evaluate_node(environment::Environment* env){
+    return interpreter_functions::eval_variable_assignment(this, env);
+  }
      
-    If_Statement::If_Statement(Expression* expr,vector<Statement*> body,Statement* other_if_ptr){
-        condition_expr = expr;
-        if_body = body;
-        other_if = other_if_ptr;
-        setNodeType(NodeType::If_Statement);
-    }
+  If_Statement::If_Statement(Expression* expr,vector<Statement*> body,Statement* other_if_ptr){
+    condition_expr = expr;
+    if_body = body;
+    other_if = other_if_ptr;
+    setNodeType(NodeType::If_Statement);
+  }
 
-    void If_Statement::printNode(int i){
-        Statement::indent(i);
-        cout << "If Statement : " << endl;
-        if(condition_expr != nullptr){
-            Statement::indent(i+1);
-            cout <<"Condition : ";
-            condition_expr->printNode(i+2);
-        }
-        Statement::indent(i+1);
-        cout << "Body : " << endl;
-        for (int j =0;j < if_body.size();j++){
-            Statement::indent(i+2);
-            if_body[j]->printNode(i+3);
-        }
-        if(other_if != nullptr){
-            Statement::indent(i+1);
-            cout << "Else Body : " << endl;
-            other_if->printNode(i+2);
-        } 
+  void If_Statement::printNode(int i){
+    Statement::indent(i);
+    cout << "If Statement : " << endl;
+    if(condition_expr != nullptr){
+      Statement::indent(i+1);
+      cout <<"Condition : ";
+      condition_expr->printNode(i+2);
     }
+    Statement::indent(i+1);
+    cout << "Body : " << endl;
+    for (int j =0;j < if_body.size();j++){
+      Statement::indent(i+2);
+      if_body[j]->printNode(i+3);
+    }
+    if(other_if != nullptr){
+      Statement::indent(i+1);
+      cout << "Else Body : " << endl;
+      other_if->printNode(i+2);
+    } 
+  }
     
-    values::RuntimeValue* If_Statement::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* If_Statement::evaluate_node(environment::Environment* env){
+    return interpreter_functions::eval_if_statement(this, env);
+  }
     
-    While_Loop::While_Loop(Expression* expr,vector<Statement*> body){
-        condition_expr = expr;
-        while_loop_body = body;
-        setNodeType(NodeType::While_Loop);
-    }
+  While_Loop::While_Loop(Expression* expr,vector<Statement*> body){
+    condition_expr = expr;
+    while_loop_body = body;
+    setNodeType(NodeType::While_Loop);
+  }
 
-    void While_Loop::printNode(int i){
-        cout << "While Loop : " << endl;
-        Statement::indent(i);
-        cout << "Condition : ";
-        condition_expr->printNode(i+1);
-        Statement::indent(i);
-        cout << "Body : " << endl;
-        for (int j =0;j < while_loop_body.size();j++){
-            Statement::indent(i+2);
-            while_loop_body[j]->printNode(i+3);
-        }
+  void While_Loop::printNode(int i){
+    cout << "While Loop : " << endl;
+    Statement::indent(i);
+    cout << "Condition : ";
+    condition_expr->printNode(i+1);
+    Statement::indent(i);
+    cout << "Body : " << endl;
+    for (int j =0;j < while_loop_body.size();j++){
+      Statement::indent(i+2);
+      while_loop_body[j]->printNode(i+3);
     }
+  }
 
-    values::RuntimeValue* While_Loop::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* While_Loop::evaluate_node(environment::Environment* env){
+    interpreter_functions::eval_while_loop(this, env);
+    return new values::Null_Interrupt_Value();
+  }
 
-    Null_Interrupt::Null_Interrupt(){
-        setNodeType(NodeType::Null_Interrupt);
-    }
+  Null_Interrupt::Null_Interrupt(){
+    setNodeType(NodeType::Null_Interrupt);
+  }
     
-    void Null_Interrupt::printNode(int i){
-        cout << "< Null_Interrupt >" << endl; 
-    }     
+  void Null_Interrupt::printNode(int i){
+    cout << "< Null_Interrupt >" << endl; 
+  }     
 
-
-    values::RuntimeValue* Null_Interrupt::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* Null_Interrupt::evaluate_node(environment::Environment* env){
+    return new values::Null_Interrupt_Value();
+  }
     
-    Break_keyWord::Break_keyWord(){
-        setNodeType(NodeType::Break_Interrupt);
-    }
+  Break_keyWord::Break_keyWord(){
+    setNodeType(NodeType::Break_Interrupt);
+  }
     
-    void Break_keyWord::printNode(int i){
-        cout << "< Break KeyWord >" << endl; 
-    }     
+  void Break_keyWord::printNode(int i){
+    cout << "< Break KeyWord >" << endl; 
+  }     
 
-    values::RuntimeValue* Break_keyWord::evaluate_node(environment::Environment* env){}
+  values::RuntimeValue* Break_keyWord::evaluate_node(environment::Environment* env){
+    return new values::Break_Interrupt_Value();
+  }
 
 }

--- a/frontend/ast.cpp
+++ b/frontend/ast.cpp
@@ -33,8 +33,9 @@ namespace ast_types{
         for(int i = 0;i < body.size();i++){
             body[i]->printNode(i+1);
         }   
-    }
+    }  
 
+    values::RuntimeValue* Program::evaluate_node(environment::Environment* env){}
 
     BinaryExpression::BinaryExpression(
         Expression* left_exp,
@@ -57,7 +58,8 @@ namespace ast_types{
         cout << "operator : " << binary_operator << endl; 
     }
 
-
+    values::RuntimeValue* BinaryExpression::evaluate_node(environment::Environment* env){}
+        
     ConditionalExpression::ConditionalExpression(
         Expression* left_exp,
         Expression* right_exp,
@@ -79,6 +81,8 @@ namespace ast_types{
         cout << "operator : " << conditional_operator << endl; 
     }
 
+    values::RuntimeValue* ConditionalExpression::evaluate_node(environment::Environment* env){}
+
     NumericLiteral::NumericLiteral(string num){
         value = stoi(num);
         setNodeType(NodeType::NumericLiteral);
@@ -89,6 +93,8 @@ namespace ast_types{
         Statement::indent(i);
         cout << "value : " << fixed << setprecision(3) << value << endl;
     }
+
+    values::RuntimeValue* NumericLiteral::evaluate_node(environment::Environment* env){}
 
     BooleanLiteral::BooleanLiteral(string data){
         if(data == "true") value = true;
@@ -101,11 +107,12 @@ namespace ast_types{
         Statement::indent(i);
         cout << "flag : " << value << endl;
     }
+    values::RuntimeValue* BooleanLiteral::evaluate_node(environment::Environment* env){}
+    
     StringLiteral::StringLiteral(string word){
         value = word;
         setNodeType(NodeType::StringLiteral);
     }
-
 
     void StringLiteral::printNode(int i) {
         cout << "StringLiteral : " << endl;
@@ -114,6 +121,8 @@ namespace ast_types{
     }
 
 
+    values::RuntimeValue* StringLiteral::evaluate_node(environment::Environment* env){}
+    
     Identifier::Identifier(string value){
         symbol = value;
         setNodeType(NodeType::Identifier);
@@ -124,7 +133,9 @@ namespace ast_types{
         Statement::indent(i);
         cout << "value : " << symbol << endl;
     }
-
+  
+    values::RuntimeValue* Identifier::evaluate_node(environment::Environment* env){}
+  
     void yoyo(){
         cout << "heloo dude"<< endl;
     }
@@ -160,6 +171,8 @@ namespace ast_types{
         
     }
 
+    values::RuntimeValue* Variable_Declaration::evaluate_node(environment::Environment* env){}
+
     Variable_Assignment::Variable_Assignment(Identifier* name,Expression* expr,DataTypes type){
         varName = name;
         expression = expr;
@@ -176,12 +189,15 @@ namespace ast_types{
         expression->printNode(i+1);
     }
 
-     If_Statement::If_Statement(Expression* expr,vector<Statement*> body,Statement* other_if_ptr){
+    values::RuntimeValue* Variable_Assignment::evaluate_node(environment::Environment* env){}
+     
+    If_Statement::If_Statement(Expression* expr,vector<Statement*> body,Statement* other_if_ptr){
         condition_expr = expr;
         if_body = body;
         other_if = other_if_ptr;
         setNodeType(NodeType::If_Statement);
     }
+
     void If_Statement::printNode(int i){
         Statement::indent(i);
         cout << "If Statement : " << endl;
@@ -203,6 +219,8 @@ namespace ast_types{
         } 
     }
     
+    values::RuntimeValue* If_Statement::evaluate_node(environment::Environment* env){}
+    
     While_Loop::While_Loop(Expression* expr,vector<Statement*> body){
         condition_expr = expr;
         while_loop_body = body;
@@ -222,6 +240,7 @@ namespace ast_types{
         }
     }
 
+    values::RuntimeValue* While_Loop::evaluate_node(environment::Environment* env){}
 
     Null_Interrupt::Null_Interrupt(){
         setNodeType(NodeType::Null_Interrupt);
@@ -232,6 +251,8 @@ namespace ast_types{
     }     
 
 
+    values::RuntimeValue* Null_Interrupt::evaluate_node(environment::Environment* env){}
+    
     Break_keyWord::Break_keyWord(){
         setNodeType(NodeType::Break_Interrupt);
     }
@@ -240,6 +261,6 @@ namespace ast_types{
         cout << "< Break KeyWord >" << endl; 
     }     
 
-
+    values::RuntimeValue* Break_keyWord::evaluate_node(environment::Environment* env){}
 
 }

--- a/frontend/ast.h
+++ b/frontend/ast.h
@@ -51,6 +51,7 @@ namespace ast_types{
             cout << "  " ;
           }
         }
+        virtual values::RuntimeValue* evaluate_node();
         virtual ~Statement(){}
     };
 
@@ -58,6 +59,7 @@ namespace ast_types{
       public :
         virtual void dummy2(){};
         virtual void printNode(int i){};
+        virtual values::RuntimeValue* evaluate_node();
         virtual ~Expression(){}
             
     };
@@ -68,6 +70,7 @@ namespace ast_types{
         Program();
         vector<Statement*> body;
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
     };
 
     class BinaryExpression : public Expression{
@@ -82,7 +85,8 @@ namespace ast_types{
           string binary_operator
         );
         void printNode(int i) override;
-    };
+        values::RuntimeValue* evaluate_node() override;
+   };
 
 
 
@@ -99,13 +103,15 @@ namespace ast_types{
         );
 
         void printNode(int i) override;
-    };
+        values::RuntimeValue* evaluate_node() override;
+   };
 
     class NumericLiteral : public Expression{
       public :
         float value;
         NumericLiteral(string number);
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
 
     };
 
@@ -114,6 +120,7 @@ namespace ast_types{
         bool value;
         BooleanLiteral(string data);
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
     };
 
     class StringLiteral :public Expression{
@@ -121,6 +128,7 @@ namespace ast_types{
         string value;
         StringLiteral(string literal);
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
     };
 
 
@@ -129,6 +137,7 @@ namespace ast_types{
         string symbol;
         Identifier(string value);
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
     };
 
 
@@ -143,6 +152,7 @@ namespace ast_types{
         values::ValueType runtime_value;
         bool nullable;
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
     };
 
     class Variable_Assignment : public Statement{
@@ -151,6 +161,7 @@ namespace ast_types{
         Identifier* varName;
         Expression* expression;
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
     };
 
     class If_Statement : public Statement{
@@ -161,7 +172,9 @@ namespace ast_types{
         vector<Statement*> if_body;
         Statement* other_if = nullptr;
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
     };
+
   
     class While_Loop : public Statement{
       public:
@@ -169,6 +182,7 @@ namespace ast_types{
         Expression* condition_expr;
         vector<Statement*> while_loop_body;
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
     };
     
     //this class acts as the placeholder for statements like break,return,continue
@@ -176,6 +190,7 @@ namespace ast_types{
       public : 
         Null_Interrupt();
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override; 
     };  
 
 
@@ -183,6 +198,8 @@ namespace ast_types{
       public :
         Break_keyWord();
         void printNode(int i) override;
+        values::RuntimeValue* evaluate_node() override;
+
     }; 
 
 }

--- a/frontend/ast.h
+++ b/frontend/ast.h
@@ -5,6 +5,7 @@
 #include<vector>
 #include<iostream>
 #include "../runtime/values.h"
+#include "../runtime/environment.h"
 
 using namespace std;
 
@@ -51,7 +52,7 @@ namespace ast_types{
             cout << "  " ;
           }
         }
-        virtual values::RuntimeValue* evaluate_node();
+        virtual values::RuntimeValue* evaluate_node(environment::Environment* env);
         virtual ~Statement(){}
     };
 
@@ -59,7 +60,7 @@ namespace ast_types{
       public :
         virtual void dummy2(){};
         virtual void printNode(int i){};
-        virtual values::RuntimeValue* evaluate_node();
+        virtual values::RuntimeValue* evaluate_node(environment::Environment* env);
         virtual ~Expression(){}
             
     };
@@ -70,7 +71,7 @@ namespace ast_types{
         Program();
         vector<Statement*> body;
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
     };
 
     class BinaryExpression : public Expression{
@@ -85,7 +86,7 @@ namespace ast_types{
           string binary_operator
         );
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
    };
 
 
@@ -103,7 +104,7 @@ namespace ast_types{
         );
 
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
    };
 
     class NumericLiteral : public Expression{
@@ -111,7 +112,7 @@ namespace ast_types{
         float value;
         NumericLiteral(string number);
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
 
     };
 
@@ -120,7 +121,7 @@ namespace ast_types{
         bool value;
         BooleanLiteral(string data);
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
     };
 
     class StringLiteral :public Expression{
@@ -128,7 +129,7 @@ namespace ast_types{
         string value;
         StringLiteral(string literal);
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
     };
 
 
@@ -137,7 +138,7 @@ namespace ast_types{
         string symbol;
         Identifier(string value);
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
     };
 
 
@@ -152,7 +153,7 @@ namespace ast_types{
         values::ValueType runtime_value;
         bool nullable;
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
     };
 
     class Variable_Assignment : public Statement{
@@ -161,7 +162,7 @@ namespace ast_types{
         Identifier* varName;
         Expression* expression;
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
     };
 
     class If_Statement : public Statement{
@@ -172,7 +173,7 @@ namespace ast_types{
         vector<Statement*> if_body;
         Statement* other_if = nullptr;
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
     };
 
   
@@ -182,7 +183,7 @@ namespace ast_types{
         Expression* condition_expr;
         vector<Statement*> while_loop_body;
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
     };
     
     //this class acts as the placeholder for statements like break,return,continue
@@ -190,7 +191,7 @@ namespace ast_types{
       public : 
         Null_Interrupt();
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override; 
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override; 
     };  
 
 
@@ -198,7 +199,7 @@ namespace ast_types{
       public :
         Break_keyWord();
         void printNode(int i) override;
-        values::RuntimeValue* evaluate_node() override;
+        values::RuntimeValue* evaluate_node(environment::Environment* env) override;
 
     }; 
 

--- a/frontend/ast.h
+++ b/frontend/ast.h
@@ -52,7 +52,7 @@ namespace ast_types{
             cout << "  " ;
           }
         }
-        virtual values::RuntimeValue* evaluate_node(environment::Environment* env);
+        virtual values::RuntimeValue* evaluate_node(environment::Environment* env){};
         virtual ~Statement(){}
     };
 
@@ -60,7 +60,6 @@ namespace ast_types{
       public :
         virtual void dummy2(){};
         virtual void printNode(int i){};
-        virtual values::RuntimeValue* evaluate_node(environment::Environment* env);
         virtual ~Expression(){}
             
     };

--- a/frontend/ast.h
+++ b/frontend/ast.h
@@ -52,7 +52,9 @@ namespace ast_types{
             cout << "  " ;
           }
         }
-        virtual values::RuntimeValue* evaluate_node(environment::Environment* env){};
+        virtual values::RuntimeValue* evaluate_node(environment::Environment* env){
+    return new values::NullValue();
+  };
         virtual ~Statement(){}
     };
 

--- a/frontend/test.cpp
+++ b/frontend/test.cpp
@@ -46,7 +46,7 @@ int fullVersion() {
   for(int i = 0;i<program.body.size();i++){
     program.body[i]->printNode(1);
   }
-  result = interpreter_functions::evaluate(&program,env);
+  result = (&program)->evaluate_node(env);
   result->printValue();
   source_file.close();
   return 0;
@@ -72,7 +72,7 @@ int repl(){
         parser.first_pass();
         program = parser.produceAST(text);
         program.printNode(0);
-        values::RuntimeValue* result = interpreter_functions::evaluate(&program,env);
+        values::RuntimeValue* result = (&program)->evaluate_node(env);
         result->printValue();
     }
     

--- a/hello.nx
+++ b/hello.nx
@@ -1,17 +1,11 @@
 var x:Number? = 1;
 var y:Boolean = true;
 while(true){
-if( 9 >  10){
-  x = 99;
-  break;
-}else{
-  if(y){
-    x = 11;
+  x = x + 1;
+  if(x == 10){
     break;
-  }else{
-    break;
+  }else if(x == 5){
+    y = false;
   }
-}
-break;
 }
 x

--- a/runtime/interpreter_part.h
+++ b/runtime/interpreter_part.h
@@ -7,7 +7,7 @@
 
 namespace interpreter_functions
 {
-    values::RuntimeValue* evaluate(ast_types::Statement* ast_node,environment::Environment* env);
+//    values::RuntimeValue* evaluate(ast_types::Statement* ast_node,environment::Environment* env);
     values::RuntimeValue* evaluate_program(ast_types::Statement* stmt,environment::Environment* env);
     values::RuntimeValue* eval_binary_expr(ast_types::Statement* ast_node,environment::Environment* env);
     values::RuntimeValue* eval_number_binary_expr(values::NumberValue* rhs,values::NumberValue* lhs,string bin_op);


### PR DESCRIPTION
The evaluate node function just wraps around the interpreter functions of the respective nodes and evaluate function is removed and all its entries have been modified to evaluate node